### PR TITLE
Compute value function internally, remove lists and provide known shapes for all numpy.ndarrays (EGM step)

### DIFF
--- a/src/consumption_retirement_model.py
+++ b/src/consumption_retirement_model.py
@@ -39,26 +39,6 @@ def utility_func_crra(
     return utility
 
 
-def _marginal_utility_crra(consumption: np.ndarray, params: pd.DataFrame) -> np.ndarray:
-    """Computes marginal utility of CRRA utility function.
-
-    Args:
-        consumption (np.ndarray): Level of the agent's consumption.
-            Array of shape (n_quad_stochastic * n_grid_wealth,).
-        params (pd.DataFrame): Model parameters indexed with multi-index of the
-            form ("category", "name") and two columns ["value", "comment"].
-            Relevant here is the CRRA coefficient theta.
-
-    Returns:
-        marginal_utility (np.ndarray): Marginal utility of CRRA consumption
-            function. Array of shape (n_quad_stochastic * n_grid_wealth,).
-    """
-    theta = params.loc[("utility_function", "theta"), "value"]
-    marginal_utility = consumption ** (-theta)
-
-    return marginal_utility
-
-
 def inverse_marginal_utility_crra(
     marginal_utility: np.ndarray, params: pd.DataFrame,
 ) -> np.ndarray:
@@ -69,6 +49,7 @@ def inverse_marginal_utility_crra(
             Array of shape (n_grid_wealth,).
         params (pd.DataFrame): Model parameters indexed with multi-index of the
             form ("category", "name") and two columns ["value", "comment"].
+            
     Returns:
         inverse_marginal_utility(np.ndarray): Inverse of the marginal utility of
             a CRRA consumption function. Array of shape (n_grid_wealth,).
@@ -176,6 +157,26 @@ def compute_expected_value(
     return expected_value
 
 
+def _marginal_utility_crra(consumption: np.ndarray, params: pd.DataFrame) -> np.ndarray:
+    """Computes marginal utility of CRRA utility function.
+
+    Args:
+        consumption (np.ndarray): Level of the agent's consumption.
+            Array of shape (n_quad_stochastic * n_grid_wealth,).
+        params (pd.DataFrame): Model parameters indexed with multi-index of the
+            form ("category", "name") and two columns ["value", "comment"].
+            Relevant here is the CRRA coefficient theta.
+
+    Returns:
+        marginal_utility (np.ndarray): Marginal utility of CRRA consumption
+            function. Array of shape (n_quad_stochastic * n_grid_wealth,).
+    """
+    theta = params.loc[("utility_function", "theta"), "value"]
+    marginal_utility = consumption ** (-theta)
+
+    return marginal_utility
+
+
 def _calc_next_period_choice_probs(
     next_period_value: np.ndarray,
     state: int,
@@ -237,7 +238,7 @@ def _calc_logsum(next_period_value: np.ndarray, lambda_: float) -> np.ndarray:
     col_max = np.amax(next_period_value, axis=0)
     next_period_value_ = next_period_value - col_max
 
-    # Eq. (14), p. 334 IJRS (2017
+    # Eq. (14), p. 334 IJRS (2017)
     logsum = col_max + lambda_ * np.log(
         np.sum(np.exp((next_period_value_) / lambda_), axis=0)
     )

--- a/src/egm_step.py
+++ b/src/egm_step.py
@@ -18,34 +18,13 @@ def do_egm_step(
     exogenous_grid: Dict[str, np.ndarray],
     utility_functions: Dict[str, callable],
     compute_expected_value: Callable,
-    next_period_policy_function: Callable,
-    next_period_value_function: Callable
+    next_period_policy_function: Dict[int, Callable],
+    next_period_value_function: Dict[int, Callable]
 ) -> Tuple[List[np.ndarray], List[np.ndarray]]:
     """Runs the Endogenous-Grid-Method Algorithm (EGM step).
     Args:
         period (int): Current period t.
         state (int): State of the agent, e.g. 0 = "retirement", 1 = "working".
-        policy (List[np.ndarray]): Nested list of np.ndarrays storing the
-            choice-specific consumption policies. Dimensions of the list are:
-            [n_periods][n_discrete_choices][2, *n_endog_wealth_grid*], where 
-            *n_endog_wealth_grid* is of variable length depending on the number of 
-            concurrent local optima for consumption. The arrays have shape
-            [2, *n_endog_wealth_grid*] and are initialized to
-            *endog_wealth_grid* = n_grid_wealth + 1.
-            Position [0, :] of the arrays contain the endogenous grid over wealth M, 
-            and [1, :] stores the corresponding value of the (consumption) policy 
-            function c(M, d), for each time period and each discrete choice. 
-        value (List[np.ndarray]): Nested list of np.ndarrays storing the
-            choice-specific value functions. Dimensions of the list are:
-            [n_periods][n_discrete_choices][2, *n_endog_wealth_grid*], where 
-            *n_endog_wealth_grid* is of variable length depending on the number of 
-            kinks and non-concave regions in the subsequent period (t + 1), which
-            propagate back to the current period t. The arrays have 
-            shape [2, *n_endog_wealth_grid*] and are initialized to
-            *endog_wealth_grid* = n_grid_wealth + 1.
-            Position [0, :] of the array contains the endogenous grid over wealth M, 
-            and [1, :] stores the corresponding value of the value function v(M, d),
-            for each time period and each discrete choice. 
         params (pd.DataFrame): Model parameters indexed with multi-index of the
             form ("category", "name") and two columns ["value", "comment"].
         options (dict): Options dictionary.
@@ -57,10 +36,19 @@ def do_egm_step(
         utility_functions (Dict[str, callable]): Dictionary of three user-supplied
             functions for computation of (i) utility, (ii) inverse marginal utility, 
             and (iii) next period marginal utility.
-        value_functions (Dict[str, callable]): Dictionary of three user-supplied
-            functions for computation of the agent's (i) value function before
-            the final period, (ii) value function in the final period, 
-            and (iii) the expected value.
+        compute_expected_value (callable): User-supplied functions for computation 
+            of the agent's expected value.
+        next_period_policy_function (Dict[int, callable]): Dictionary of partial
+            functions (one for each discrete choice) functions to compute agent's 
+            choice-specific policy function of the next period. 
+            It takes the current period matrix of potential next-period wealths
+            as input.
+        next_period_value_function (Dict[int, callable]): Dictionary of partial
+            functions (one for each discrete choice) functions to compute agent's 
+            choice-specific value function of the next period.
+            It takes the current period matrix of potential next-period wealths
+            as input.
+
     Returns:
         (tuple) Tuple containing
         
@@ -90,43 +78,40 @@ def do_egm_step(
     )
     # Interpolate next period policy and values to match the
     # contemporary matrix of potential next period wealths
-    next_period_value_interp = map_value_to_current_matrix(
-        period,
+    next_period_value = get_next_period_value(
         matrix_next_period_wealth=matrix_next_period_wealth,
-        params=params,
         options=options,
-        compute_utility=utility_functions["utility"],
         next_period_value_function=next_period_value_function,
     )
 
-    next_period_consumption_interp = map_next_period_policy(
+    next_period_policy = get_next_period_policy(
         matrix_next_period_wealth,
         options=options,
         next_period_policy_function=next_period_policy_function,
     )
 
     # i) Current period consumption & endogenous wealth grid
-    current_period_consumption = map_consumption_to_current_matrix(
+    current_period_policy = get_current_period_policy(
         state,
-        next_period_consumption=next_period_consumption_interp,
+        next_period_policy=next_period_policy,
         matrix_next_period_wealth=matrix_next_period_wealth,
         next_period_marginal_wealth=next_period_marginal_wealth,
-        next_period_value_interp=next_period_value_interp,
+        next_period_value=next_period_value,
         params=params,
         options=options,
         quad_weights=exogenous_grid["quadrature_weights"],
         utility_functions=utility_functions,
     )
     endog_wealth_grid = get_endogenous_wealth_grid(
-        current_period_consumption, exog_savings_grid=exogenous_grid["savings"]
+        current_period_policy, exog_savings_grid=exogenous_grid["savings"]
     )
 
     # ii) Expected & current period value
     expected_value, current_period_value = get_expected_and_current_period_value(
         state,
-        next_period_value=next_period_value_interp,
+        next_period_value=next_period_value,
         matrix_next_period_wealth=matrix_next_period_wealth,
-        current_period_consumption=current_period_consumption,
+        current_period_policy=current_period_policy,
         quad_weights=exogenous_grid["quadrature_weights"],
         params=params,
         options=options,
@@ -135,77 +120,16 @@ def do_egm_step(
     )
 
     current_policy[0, 1:] = endog_wealth_grid
-    current_policy[1, 1:] = current_period_consumption
+    current_policy[1, 1:] = current_period_policy
 
     current_value[0, 1:] = endog_wealth_grid
     current_value[1, 1:] = current_period_value
 
-    current_policy, current_value = set_first_elements(
+    current_policy, current_value = _set_first_elements(
         current_policy, current_value, expected_value
     )
 
     return current_policy, current_value, expected_value
-
-
-def set_first_elements(
-    policy: np.ndarray, value: np.ndarray, expected_value: np.ndarray
-) -> Tuple[np.ndarray, np.ndarray]:
-    """Sets first value to expected value and the other elements to zero."""
-    policy[0, 0] = 0
-    policy[1, 0] = 0
-
-    value[0, 0] = 0
-    value[1, 0] = expected_value[0]
-
-    return policy, value
-
-
-def map_next_period_policy(
-    matrix_next_period_wealth: np.ndarray,
-    options: Dict[str, int],
-    next_period_policy_function: Dict[int, callable],
-) -> np.ndarray:
-    """Computes consumption in the next period via linear interpolation.
-    Extrapolate lineary in wealth regions beyond the grid, i.e. larger
-    than "max_wealth" specifiec in the ``params`` dictionary.
-
-    Args:
-        policy (List[np.ndarray]): Nested list of np.ndarrays storing the
-            choice-specific consumption policies of the next period. Dimensions 
-            of the list are: [n_discrete_choices][2, *n_endog_wealth_grid*], where 
-            *n_endog_wealth_grid* is of variable length depending on the number of 
-            concurrent local optima for consumption. The arrays have shape
-            [2, *n_endog_wealth_grid*] and are initialized to
-            *endog_wealth_grid* = n_grid_wealth + 1. We include one additional
-            grid point to the left of the endogenous wealth grid, which we set
-            to zero (that's why we have n_grid_wealth + 1 initial points). 
-            Position [0, :] of the arrays contain the endogenous grid over wealth M, 
-            and [1, :] stores the corresponding value of the (consumption) policy 
-            function c(M, d), for each time period and each discrete choice.
-        matrix_next_period_wealth (np.ndarray): Array of all possible next period
-            wealths with shape (n_quad_stochastic, n_grid_wealth).
-        options (dict): Options dictionary.
-
-    Returns:
-        next_period_consumption_interp (np.ndarray): Array of next period
-            consumption of shape (n_choices, n_quad_stochastic * n_grid_wealth).
-            Contains interpolated values.
-    """
-    n_choices = options["n_discrete_choices"]
-    n_grid_wealth = options["grid_points_wealth"]
-    n_quad_stochastic = options["quadrature_points_stochastic"]
-    choice_range = [1] if n_choices < 2 else range(n_choices)
-
-    next_period_policy = np.empty((n_choices, n_quad_stochastic * n_grid_wealth))
-
-    for index, state in enumerate(choice_range):
-        interpolate_next_period_policy = next_period_policy_function[state]
-
-        next_period_policy[index, :] = interpolate_next_period_policy(
-            matrix_next_period_wealth.flatten("F")
-        )
-
-    return next_period_policy
 
 
 def get_next_period_wealth_matrices(
@@ -269,26 +193,23 @@ def get_next_period_wealth_matrices(
     return matrix_next_period_wealth, next_period_marginal_wealth
 
 
-def map_value_to_current_matrix(
-    period: int,
+def get_next_period_value(
     matrix_next_period_wealth: np.ndarray,
-    params: pd.DataFrame,
     options: Dict[str, int],
-    compute_utility: Callable,
     next_period_value_function: Dict[int, callable],
 ) -> np.ndarray:
     """Maps next-period value onto this period's matrix of next-period wealth.
+
     Args:
-        period (int): Current period t.
         matrix_next_period_wealth (np.ndarray): Array of all possible next period
             wealths with shape (n_quad_stochastic, n_grid_wealth).
-        params (pd.DataFrame): Model parameters indexed with multi-index of the
-            form ("category", "name") and two columns ["value", "comment"].
         options (dict): Options dictionary.
-        value_functions (Dict[str, callable]): Dictionary of three user-supplied
-            functions for computation of the agent's (i) value function before
-            the final period, (ii) value function in the final period, 
-            and (iii) the expected value.
+        next_period_value_function (Dict[int, callable]): Dictionary of partial
+            functions (one for each discrete choice) functions to compute agent's 
+            choice-specific value function of the next period.
+            It takes the current period matrix of potential next-period wealths
+            as input.
+
     Returns:
         next_period_value_interp (np.ndarray): Array containing interpolated
             values of next period choice-specific value function. We use
@@ -316,19 +237,68 @@ def map_value_to_current_matrix(
     return next_period_value
 
 
-def map_consumption_to_current_matrix(
+def get_next_period_policy(
+    matrix_next_period_wealth: np.ndarray,
+    options: Dict[str, int],
+    next_period_policy_function: Dict[int, callable],
+) -> np.ndarray:
+    """Computes the next-period policy via linear interpolation.
+
+    Extrapolate lineary in wealth regions beyond the grid, i.e. larger
+    than "max_wealth" specifiec in the ``params`` dictionary.
+
+    Args:
+        policy (List[np.ndarray]): Nested list of np.ndarrays storing the
+            choice-specific consumption policies of the next period. Dimensions 
+            of the list are: [n_discrete_choices][2, *n_endog_wealth_grid*], where 
+            *n_endog_wealth_grid* is of variable length depending on the number of 
+            concurrent local optima for consumption. The arrays have shape
+            [2, *n_endog_wealth_grid*] and are initialized to
+            *endog_wealth_grid* = n_grid_wealth + 1. We include one additional
+            grid point to the left of the endogenous wealth grid, which we set
+            to zero (that's why we have n_grid_wealth + 1 initial points). 
+            Position [0, :] of the arrays contain the endogenous grid over wealth M, 
+            and [1, :] stores the corresponding value of the (consumption) policy 
+            function c(M, d), for each time period and each discrete choice.
+        matrix_next_period_wealth (np.ndarray): Array of all possible next period
+            wealths with shape (n_quad_stochastic, n_grid_wealth).
+        options (dict): Options dictionary.
+
+    Returns:
+        next_period_policy (np.ndarray): Array of next period
+            consumption of shape (n_choices, n_quad_stochastic * n_grid_wealth).
+            Contains interpolated values.
+    """
+    n_choices = options["n_discrete_choices"]
+    n_grid_wealth = options["grid_points_wealth"]
+    n_quad_stochastic = options["quadrature_points_stochastic"]
+    choice_range = [1] if n_choices < 2 else range(n_choices)
+
+    next_period_policy = np.empty((n_choices, n_quad_stochastic * n_grid_wealth))
+
+    for index, state in enumerate(choice_range):
+        interpolate_next_period_policy = next_period_policy_function[state]
+
+        next_period_policy[index, :] = interpolate_next_period_policy(
+            matrix_next_period_wealth.flatten("F")
+        )
+
+    return next_period_policy
+
+
+def get_current_period_policy(
     state: int,
-    next_period_consumption: np.ndarray,
+    next_period_policy: np.ndarray,
     matrix_next_period_wealth: np.ndarray,
     next_period_marginal_wealth: np.ndarray,
-    next_period_value_interp: np.ndarray,
+    next_period_value: np.ndarray,
     params: pd.DataFrame,
     options: Dict[str, int],
     quad_weights: np.ndarray,
     utility_functions: Dict[str, callable],
 ) -> np.ndarray:
-    """Maps next-period consumption onto matrix of next-period wealth.
-    Returns current period consumption.
+    """Computes the current period policy.
+
     Args:
         state (int): State of the agent, e.g. 0 = "retirement", 1 = "working".
         true_next_period_policy (List[np.ndarray]): Nested list of np.ndarrays storing
@@ -348,7 +318,7 @@ def map_consumption_to_current_matrix(
             wealths with shape (n_quad_stochastic, n_grid_wealth).
         next_period_marginal_wealth (np.ndarray): Array of all possible next period
             marginal wealths. Also of shape (n_quad_stochastic, n_grid_wealth)
-        next_period_value_interp (np.ndarray): Array containing interpolated
+        next_period_value (np.ndarray): Array containing interpolated
             values of next period choice-specific value function.
             Shape (n_choices, n_quad_stochastic * n_grid_wealth).
         params (pd.DataFrame): Model parameters indexed with multi-index of the
@@ -360,8 +330,9 @@ def map_consumption_to_current_matrix(
         utility_functions (Dict[str, callable]): Dictionary of three user-supplied
             functions for computation of (i) utility, (ii) inverse marginal utility, 
             and (iii) next period marginal utility.
+
     Returns:
-        current_period_consumption (np.ndarray): Consumption in the current
+        current_period_policy (np.ndarray): Policy (consumption) in the current
             period. Array of shape (n_grid_wealth,).
     """
     beta = params.loc[("beta", "beta"), "value"]
@@ -372,8 +343,8 @@ def map_consumption_to_current_matrix(
 
     next_period_marginal_utility = _compute_next_period_marginal_utility(
         state,
-        next_period_consumption=next_period_consumption,
-        next_period_value=next_period_value_interp,
+        next_period_consumption=next_period_policy,
+        next_period_value=next_period_value,
         params=params,
         options=options,
     )
@@ -386,19 +357,20 @@ def map_consumption_to_current_matrix(
         next_period_marginal_wealth=next_period_marginal_wealth,
         quad_weights=quad_weights,
     )
-    current_period_consumption = _inv_marg_utility_func(
+    current_period_policy = _inv_marg_utility_func(
         marginal_utility=beta * rhs_euler, params=params
     )
 
-    return current_period_consumption
+    return current_period_policy
 
 
 def get_endogenous_wealth_grid(
-    current_period_consumption: np.ndarray, exog_savings_grid: np.ndarray
+    current_period_policy: np.ndarray, exog_savings_grid: np.ndarray
 ) -> np.ndarray:
-    """Returns the endogenous grid over wealth of the current period.
+    """Returns the endogenous wealth grid of the current period.
+    .
     Args:
-        current_period_consumption (np.ndarray): Consumption in the current
+        current_period_policy (np.ndarray): Consumption in the current
             period. Array of shape (n_grid_wealth,).
         exog_savings_grid (np.ndarray): Exogenous grid over savings.
             Array of shape (n_grid_wealth,).
@@ -407,7 +379,7 @@ def get_endogenous_wealth_grid(
         endog_wealth_grid (np.ndarray): Endogenous wealth grid of shape
             (n_grid_wealth,).
     """
-    endog_wealth_grid = exog_savings_grid + current_period_consumption
+    endog_wealth_grid = exog_savings_grid + current_period_policy
 
     return endog_wealth_grid
 
@@ -416,14 +388,14 @@ def get_expected_and_current_period_value(
     state: int,
     next_period_value: np.ndarray,
     matrix_next_period_wealth: np.ndarray,
-    current_period_consumption: np.ndarray,
+    current_period_policy: np.ndarray,
     quad_weights: np.ndarray,
     params: pd.DataFrame,
     options: Dict[str, int],
     compute_utility: Callable,
     compute_expected_value: Callable,
 ) -> Tuple[np.ndarray, np.ndarray]:
-    """Computes the expected (next period) value and the current period's value.
+    """Computes the expected (next-period) value and the current period's value.
     
     Args:
         state (int): State of the agent, e.g. 0 = "retirement", 1 = "working".
@@ -432,7 +404,7 @@ def get_expected_and_current_period_value(
             Shape (n_choices, n_quad_stochastic * n_grid_wealth).
         matrix_next_period_wealth (np.ndarray): Array of all possible next period
             wealths with shape (n_quad_stochastic, n_grid_wealth).
-        current_period_consumption (np.ndarray): Consumption in the current
+        current_period_policy (np.ndarray): Consumption in the current
             period. Array of shape (n_grid_wealth,).
         quad_weights (np.ndarray): Weights associated with the quadrature points
             of shape (n_quad_stochastic,). Used for integration over the
@@ -462,7 +434,7 @@ def get_expected_and_current_period_value(
         options=options,
     )
 
-    utility = compute_utility(current_period_consumption, state, params)
+    utility = compute_utility(current_period_policy, state, params)
     current_period_value = utility + beta * expected_value
 
     return expected_value, current_period_value
@@ -472,6 +444,7 @@ def _calc_stochastic_income(
     period: int, shock: float, params: pd.DataFrame, options: Dict[str, int]
 ) -> float:
     """Computes the current level of deterministic and stochastic income.
+
     Note that income is paid at the end of the current period, i.e. after
     the (potential) labor supply choice has been made. This is equivalent to
     allowing income to be dependent on a lagged choice of labor supply.
@@ -481,6 +454,7 @@ def _calc_stochastic_income(
     labor_income = constant + alpha_1 * age + alpha_2 * age**2
     They include a constant as well as two coefficents on age and age squared,
     respectively. Note that the last one (alpha_2) typically has a negative sign.
+
     Args:
         period (int): Curent period t.
         shock (float): Stochastic shock on labor income, which may or may not
@@ -489,6 +463,7 @@ def _calc_stochastic_income(
             form ("category", "name") and two columns ["value", "comment"].
             Relevant here are the coefficients of the wage equation.
         options (dict): Options dictionary.
+
     Returns:
         stochastic_income (float): End of period income composed of a
             deterministic component, i.e. age-dependent labor income, and a
@@ -510,124 +485,6 @@ def _calc_stochastic_income(
     return stochastic_income
 
 
-def _interpolate_next_period_consumption(
-    true_next_period_policy: List[np.ndarray],
-    matrix_next_period_wealth: np.ndarray,
-    options: Dict[str, int],
-) -> np.ndarray:
-    """Computes consumption in the next period via linear interpolation.
-    Extrapolate lineary in wealth regions beyond the grid, i.e. larger
-    than "max_wealth" specifiec in the ``params`` dictionary.
-    Args:
-        policy (List[np.ndarray]): Nested list of np.ndarrays storing the
-            choice-specific consumption policies of the next period. Dimensions 
-            of the list are: [n_discrete_choices][2, *n_endog_wealth_grid*], where 
-            *n_endog_wealth_grid* is of variable length depending on the number of 
-            concurrent local optima for consumption. The arrays have shape
-            [2, *n_endog_wealth_grid*] and are initialized to
-            *endog_wealth_grid* = n_grid_wealth + 1. We include one additional
-            grid point to the left of the endogenous wealth grid, which we set
-            to zero (that's why we have n_grid_wealth + 1 initial points). 
-            Position [0, :] of the arrays contain the endogenous grid over wealth M, 
-            and [1, :] stores the corresponding value of the (consumption) policy 
-            function c(M, d), for each time period and each discrete choice.
-        matrix_next_period_wealth (np.ndarray): Array of all possible next period
-            wealths with shape (n_quad_stochastic, n_grid_wealth).
-        options (dict): Options dictionary.
-    Returns:
-        next_period_consumption_interp (np.ndarray): Array of next period
-            consumption of shape (n_choices, n_quad_stochastic * n_grid_wealth).
-            Contains interpolated values.
-    """
-    n_choices = options["n_discrete_choices"]
-    n_grid_wealth = options["grid_points_wealth"]
-    n_quad_stochastic = options["quadrature_points_stochastic"]
-    choice_range = [0] if n_choices < 2 else range(n_choices)
-
-    next_period_consumption_interp = np.empty(
-        (n_choices, n_quad_stochastic * n_grid_wealth)
-    )
-
-    for state_index in choice_range:
-        true_next_period_wealth = true_next_period_policy[state_index][0, :]
-        next_period_consumption = true_next_period_policy[state_index][1, :]
-
-        interpolation_func = interpolate.interp1d(
-            true_next_period_wealth,
-            next_period_consumption,
-            bounds_error=False,
-            fill_value="extrapolate",
-            kind="linear",
-        )
-        next_period_consumption_interp[state_index, :] = interpolation_func(
-            matrix_next_period_wealth
-        ).flatten("F")
-
-    return next_period_consumption_interp
-
-
-def _interpolate_next_period_value(
-    state: int,
-    true_value: np.ndarray,
-    matrix_next_period_wealth: np.ndarray,
-    params: pd.DataFrame,
-    compute_utility: Callable,
-) -> np.ndarray:
-    """Computes the value function of the next period t+1.
-    Take into account credit-constrained regions.
-    Use interpolation in non-constrained region and apply extrapolation
-    where the observed wealth exceeds the maximum wealth level.
-    Args:
-        state (int): State of the agent, e.g. 0 = "retirement", 1 = "working".
-        true_value (np.ndarray): Actual next period value, obtained from
-            previous (t + 1) run of the EGM and Upper Envelope Algorithms.
-            Array of shape (2, *n_endog_wealth_grid*), where *n_endog_wealth_grid*
-            is of variable length depending on the number of kinks and non-concave 
-            regions in the next period.
-        matrix_next_period_wealth (np.ndarray): Array of of all possible next
-            period wealths. Shape (n_quad_stochastic, n_grid_wealth).
-        params (pd.DataFrame): Model parameters indexed with multi-index of the
-            form ("category", "name") and two columns ["value", "comment"].
-        options (dict): Options dictionary.
-        uility_func (callable): Utility function.
-    Returns:
-        next_period_value_interp (np.ndarray): Interpolated next period value function. 
-            In credit constrained regions, the analytical part of the value function
-            is used. Array of shape (n_quad_stochastic * n_grid_wealth,).
-    """
-    beta = params.loc[("beta", "beta"), "value"]
-
-    matrix_next_period_wealth = matrix_next_period_wealth.flatten("F")
-    next_period_value_interp = np.empty(matrix_next_period_wealth.shape)
-
-    # Mark credit constrained region
-    constrained_region = matrix_next_period_wealth < true_value[0, 1]
-
-    # Calculate t+1 value function in constrained region using
-    # the analytical part
-    next_period_utility = compute_utility(
-        matrix_next_period_wealth[constrained_region], state, params
-    )
-    next_period_value_interp[constrained_region] = (
-        next_period_utility + beta * true_value[1, 0]  # next_period_value
-    )
-
-    # Calculate t+1 value function in non-constrained region
-    # via inter- and extrapolation
-    interpolation_func = interpolate.interp1d(
-        x=true_value[0, :],  # endogenous wealth grid
-        y=true_value[1, :],  # value_function
-        bounds_error=False,
-        fill_value="extrapolate",
-        kind="linear",
-    )
-    next_period_value_interp[~constrained_region] = interpolation_func(
-        matrix_next_period_wealth[~constrained_region]
-    )
-
-    return next_period_value_interp
-
-
 def _calc_rhs_euler(
     next_period_marginal_utility: np.ndarray,
     matrix_next_period_wealth: np.ndarray,
@@ -635,6 +492,7 @@ def _calc_rhs_euler(
     quad_weights: np.ndarray,
 ) -> np.ndarray:
     """Computes the right-hand side of the Euler equation, p. 337 IJRS (2017).
+
     Args:
         next_period_marginal_utility (np.ndarray): Array of next period's
             marginal utility of shape (n_quad_stochastic * n_grid_wealth,).
@@ -645,6 +503,7 @@ def _calc_rhs_euler(
         quad_weights (np.ndarray): Weights associated with the quadrature points
             of shape (n_quad_stochastic,). Used for integration over the
             stochastic income component in the Euler equation.
+            
     Returns:
         rhs_euler (np.ndarray): Right-hand side of the Euler equation.
             Shape (n_grid_wealth,).
@@ -659,3 +518,16 @@ def _calc_rhs_euler(
     )
 
     return rhs_euler
+
+
+def _set_first_elements(
+    policy: np.ndarray, value: np.ndarray, expected_value: np.ndarray
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Sets first value to expected value and the other elements to zero."""
+    policy[0, 0] = 0
+    policy[1, 0] = 0
+
+    value[0, 0] = 0
+    value[1, 0] = expected_value[0]
+
+    return policy, value

--- a/src/egm_step.py
+++ b/src/egm_step.py
@@ -3,6 +3,7 @@ from typing import Callable, Dict, List, Tuple
 from functools import partial
 
 import numpy as np
+from numpy.lib.index_tricks import nd_grid
 import pandas as pd
 
 from scipy import interpolate
@@ -129,22 +130,26 @@ def do_egm_step(
         compute_expected_value=compute_expected_value,
     )
 
-    current_policy = np.empty((2, endog_wealth_grid.shape[0] + 1))
-    current_policy[0, 1:] = endog_wealth_grid
-    current_policy[1, 1:] = current_period_consumption
+    n_grid_wealth = options["grid_points_wealth"]
 
-    current_value = np.empty((2, endog_wealth_grid.shape[0] + 1))
-    current_value[0, 1:] = endog_wealth_grid
-    current_value[1, 1:] = current_period_value
+    current_policy = np.empty((2, int(1.1 * n_grid_wealth)))
+    current_policy[:] = np.nan
+    current_policy[0, 1 : n_grid_wealth + 1] = endog_wealth_grid
+    current_policy[1, 1 : n_grid_wealth + 1] = current_period_consumption
 
-    current_policy, current_value = _adjust_first_elements(
+    current_value = np.empty((2, int(1.1 * n_grid_wealth)))
+    current_value[:] = np.nan
+    current_value[0, 1 : n_grid_wealth + 1] = endog_wealth_grid
+    current_value[1, 1 : n_grid_wealth + 1] = current_period_value
+
+    current_policy, current_value = adjust_first_elements(
         current_policy, current_value, expected_value
     )
 
     return current_policy, current_value, expected_value
 
 
-def _adjust_first_elements(
+def adjust_first_elements(
     policy: np.ndarray, value: np.ndarray, expected_value: np.ndarray
 ) -> Tuple[np.ndarray, np.ndarray]:
     """

--- a/src/solve.py
+++ b/src/solve.py
@@ -144,7 +144,7 @@ def solve_dcegm(
                     expected_value=expected_value,
                     params=params,
                     options=options,
-                    utility_func=utility_functions["utility"],
+                    compute_utility=utility_functions["utility"],
                 )
 
                 policy[period][state] = policy_refined

--- a/src/solve.py
+++ b/src/solve.py
@@ -143,16 +143,18 @@ def solve_dcegm(
                 )
 
             # get policy & value (interpolation) functions
+            # test[:, ~np.isnan(test).any(axis=0)]
             current_value_function[state] = partial(
                 interpolate_value,
-                value=current_value,
+                value=current_value[:, ~np.isnan(current_value).any(axis=0)],
                 state=state,
                 params=params,
                 utility_func=utility_functions["utility"],
             )
 
             current_policy_function[state] = partial(
-                interpolate_policy, policy=current_policy
+                interpolate_policy,
+                policy=current_policy[:, ~np.isnan(current_policy).any(axis=0)],
             )
 
             # Append to list

--- a/src/solve.py
+++ b/src/solve.py
@@ -89,7 +89,6 @@ def solve_dcegm(
     # We cannot use multi-dim np.ndarrays here, since the length of
     # the grid is altered by the Upper Envelope step!
     policy, value = _create_multi_dim_lists(options)
-    policy, value = set_first_elements_to_zero(policy, value, options)
     policy, value = solve_final_period(
         policy,
         value,
@@ -156,7 +155,7 @@ def solve_dcegm(
                 interpolate_policy, policy=current_policy
             )
 
-            # Update lists
+            # Append to list
             policy[period][index] = current_policy
             value[period][index] = current_value
 
@@ -353,6 +352,8 @@ def solve_final_period(
         policy[n_periods - 1][state_index][1, 1:] = copy.deepcopy(
             policy[n_periods - 1][state_index][0, 1:]
         )  # c(M, d)
+        policy[n_periods - 1][state_index][0, 0] = 0
+        policy[n_periods - 1][state_index][1, 0] = 0
 
         value[n_periods - 1][state_index][0, 2:] = compute_utility(
             policy[n_periods - 1][state_index][0, 2:], state, params
@@ -360,7 +361,7 @@ def solve_final_period(
         value[n_periods - 1][state_index][1, 2:] = compute_utility(
             policy[n_periods - 1][state_index][1, 2:], state, params
         )
-
+        value[n_periods - 1][state_index][0, 0] = 0
         value[n_periods - 1][state_index][:, 2] = 0
 
     return policy, value

--- a/src/upper_envelope_step.py
+++ b/src/upper_envelope_step.py
@@ -21,6 +21,7 @@ def do_upper_envelope_step(
     compute_utility: Callable,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Runs the Upper Envelope algorithm and drops sub-optimal points.
+
     Calculates the upper envelope over the overlapping segments of the
     decision-specific value functions, which in fact are value "correspondences"
     in this case, where multiple solutions are detected. The dominated grid
@@ -43,24 +44,13 @@ def do_upper_envelope_step(
     subsequent periods t + 1, t + 2, ..., T under the optimal consumption policy.
     
     Args:
-        policy (List[np.ndarray]): Nested list of np.ndarrays storing the
-            choice-specific consumption policies. Dimensions of the list are:
-            [n_periods][n_discrete_choices][2, *n_endog_wealth_grid*], where 
-            *n_endog_wealth_grid* is of variable length depending on the number of 
-            concurrent local optima for consumption. In the case where the consumption
-            policy function has no discontinuities, i.e. only one solution to the 
-            Euler equation exists, we have *n_endog_wealth_grid* = n_grid_wealth + 1.
-            The arrays have shape [2, *n_endog_wealth_grid*].
+        policy (np.ndarray): Array of choice-specific consumption policy 
+            of shape (2, n_grid_wealth).
             Position [0, :] of the arrays contain the endogenous grid over wealth M, 
             and [1, :] stores the corresponding value of the (consumption) policy 
             function c(M, d), for each time period and each discrete choice.  
-        value (List[np.ndarray]): Nested list of np.ndarrays storing the
-            choice-specific value functions. Dimensions of the list are:
-            [n_periods][n_discrete_choices][2, *n_endog_wealth_grid*], where 
-            *n_endog_wealth_grid* is of variable length depending on the number of 
-            kinks and non-concave regions. In the case where the value function
-            has no non-concavities, we have *n_endog_wealth_grid* = n_grid_wealth + 1.
-            The arrays have shape [2, *n_endog_wealth_grid*].
+        value (np.ndarray): Array of choice-specific value function
+            of shape (2, n_grid_wealth).
             Position [0, :] of the array contains the endogenous grid over wealth M, 
             and [1, :] stores the corresponding value of the value function v(M, d),
             for each time period and each discrete choice.
@@ -75,13 +65,11 @@ def do_upper_envelope_step(
         - policy_refined (np.ndarray): Worker's *refined* (consumption) policy 
             function of the current period, where suboptimal points have been dropped 
             and the kink points along with the corresponding interpolated values of 
-            the policy function have been added. Shape (2, *n_grid_refined*), where 
-            *n_grid_refined* is the length of the *refined* endogenous wealth grid.
+            the policy function have been added. Shape (2, 1.1 * n_grid_wealth).
         - value_refined (np.ndarray): Worker's *refined* value function of the 
             current period, where suboptimal points have been dropped and the kink 
             points along with the corresponding interpolated values of the value 
-            function have been added. Shape (2, *n_grid_refined*), where 
-            *n_grid_refined* is the length of the *refined* endogenous wealth grid.
+            function have been added. Shape (2, 1.1 * n_grid_wealth).
     """
     policy = copy.deepcopy(policy)
     value = copy.deepcopy(value)
@@ -122,7 +110,7 @@ def do_upper_envelope_step(
         policy_refined = policy
 
     # Fill array with nans to fit 10% extra grid points,
-    # since true shape unknown
+    # as true shape unknown
     n_grid_wealth = options["grid_points_wealth"]
     policy_refined_with_nans = np.empty((2, int(1.1 * n_grid_wealth)))
     value_refined_with_nans = np.empty((2, int(1.1 * n_grid_wealth)))
@@ -139,6 +127,7 @@ def locate_non_concave_regions_and_refine(
     value,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Locates non-concave regions and refines the value "correspondence".
+
     Non-concave regions in the value function are reflected by non-monotonous
     regions in the underlying endogenous wealth grid.
     Multiple solutions to the Euler equation cause the standard EGM loop to
@@ -166,7 +155,6 @@ def locate_non_concave_regions_and_refine(
             containing the kink points and corresponding interpolated values of the 
             *refined* value function that have been added to ``value_refined``.
             *n_kink_points* is of variable length.
-    
         - index_dominated_points (np.ndarray): Array of shape (*n_dominated_points*,) 
             containing the indices of dominated points in the endogenous wealth grid,
             where *n_dominated_points* is of variable length.
@@ -238,6 +226,7 @@ def refine_policy(
         index_dominated_points (np.ndarray): Array of shape (*n_dominated_points*,) 
             containing the indices of dominated points in the endogenous wealth grid,
             where *n_dominated_points* is of variable length.
+
     Returns:
         policy_refined (np.ndarray): Array of shape (2, *n_grid_refined*)
             containing the *refined* choice-specific policy function, which means that 
@@ -341,6 +330,7 @@ def _compute_upper_envelope(
     segments: List[np.ndarray],
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Computes upper envelope and refines value function "correspondence".
+
     The upper envelope algorithm detects suboptimal points in the value function
     "correspondence. Consequently, (i) the suboptimal points are removed and the
     (ii) kink points along with their corresponding interpolated values are included.
@@ -355,6 +345,7 @@ def _compute_upper_envelope(
             np.ndarrays of shape (2, *len_non_monotonous*), where 
             *len_non_monotonous* is of variable length denoting the length of the 
             given non-monotonous segment.
+
     Returns:
         (tuple) Tuple containing:
         - points_upper_env_refined (np.ndarray): Array containing the *refined*
@@ -517,7 +508,8 @@ def _augment_grid(
         params (pd.DataFrame): Model parameters indexed with multi-index of the
             form ("category", "name") and two columns ["value", "comment"].
         options (dict): Options dictionary.
-        compute_utility (callable): The agent's utility function. 
+        compute_utility (callable): The agent's utility function.
+
     Returns:
         policy_augmented (np.ndarray): Array containing endogenous grid and 
             policy function with ancillary points added to the left. 
@@ -558,8 +550,10 @@ def _partition_grid(
     value_correspondence: np.ndarray, j: int
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Splits the grid into two parts, 1,..., j and j, j+1,..., J.
+
     Note that the index ``j``, after which the separation occurs,
     is also included in the second parition.
+
     Args:
         value_correspondence (np.ndarray):  Array storing the choice-specific 
             value function "correspondences". Shape (2, *n_endog_wealth_grid*), where 
@@ -569,6 +563,7 @@ def _partition_grid(
             rather than a function due to non-concavities.
         j (int): Index denoting the location where the endogenous wealth grid is
             separated.
+
     Returns:
         part_one (np.ndarray): Array of shape (2, : ``j`` + 1) containing the first 
             partition, where
@@ -593,7 +588,9 @@ def _find_dominated_points(
     value_correspondence: np.ndarray, value_refined: np.ndarray, significance: int = 10,
 ) -> np.ndarray:
     """Returns indexes of dominated points in the value function "correspondence".
+
     Equality is measured up to 10**(-``significance``).
+
     Args:
         value_correspondence (np.ndarray):  Array storing the choice-specific 
             value function "correspondences". Shape (2, *n_endog_wealth_grid*), where 
@@ -608,6 +605,7 @@ def _find_dominated_points(
             the *refined* endogenous grid.
         significance (float): Level of significance. Equality is measured up to 
             10**(-``significance``).
+            
     Returns:
         index_dominated_points (np.ndarray): Array of shape (*n_dominated_points*,) 
             containing the indices of dominated points in the endogenous wealth grid,

--- a/src/upper_envelope_step.py
+++ b/src/upper_envelope_step.py
@@ -83,8 +83,8 @@ def do_upper_envelope_step(
             function have been added. Shape (2, *n_grid_refined*), where 
             *n_grid_refined* is the length of the *refined* endogenous wealth grid.
     """
-    policy = copy.deepcopy(policy)
-    value = copy.deepcopy(value)
+    policy = copy.deepcopy(policy[:, ~np.isnan(policy).any(axis=0)])
+    value = copy.deepcopy(value[:, ~np.isnan(value).any(axis=0)])
 
     min_wealth_grid = np.min(value[0, 1:])
 
@@ -96,7 +96,7 @@ def do_upper_envelope_step(
         ) = locate_non_concave_regions_and_refine(value)
     else:
         # Non-concave region coincides with credit constraint.
-        # This happens when we have a non-monotonicity in the endogenous wealth grid
+        # This happens when there is a non-monotonicity in the endogenous wealth grid
         # that goes below the first point.
         # Solution: Value function to the left of the first point is analytical,
         # so we just need to add some points to the left of the first grid point.

--- a/src/upper_envelope_step.py
+++ b/src/upper_envelope_step.py
@@ -83,7 +83,7 @@ def do_upper_envelope_step(
             function have been added. Shape (2, *n_grid_refined*), where 
             *n_grid_refined* is the length of the *refined* endogenous wealth grid.
     """
-    policy = copy.deepcopy(policy)  # state == 1 "working"
+    policy = copy.deepcopy(policy)
     value = copy.deepcopy(value)
 
     min_wealth_grid = np.min(value[0, 1:])
@@ -121,7 +121,17 @@ def do_upper_envelope_step(
     else:
         policy_refined = policy
 
-    return policy_refined, value_refined
+    # NEW
+    n_grid_wealth = options["grid_points_wealth"]
+    policy_refined_with_nans = np.empty((2, int(1.1 * n_grid_wealth)))
+    value_refined_with_nans = np.empty((2, int(1.1 * n_grid_wealth)))
+    policy_refined_with_nans[:] = np.nan
+    value_refined_with_nans[:] = np.nan
+
+    policy_refined_with_nans[:, : policy_refined.shape[1]] = policy_refined
+    value_refined_with_nans[:, : value_refined.shape[1]] = value_refined
+
+    return policy_refined_with_nans, value_refined_with_nans
 
 
 def locate_non_concave_regions_and_refine(


### PR DESCRIPTION
**What has changed?**

- In ``solve.py`` and ``egm_step.py``: Replace all lists with numpy.ndarrays 
- Provide known shapes for all numpy.ndarrays
- Compute value functions internally from user-specified utility functions
- Set up interpolation functions for next-period policy & value beforehand and pass them into ``do_egm_step()`` as ``Dict[int, callable]``, i.e. a separate interpolation function for each discrete choice

**Still to do**

- Speed up: Calculate interpolation functions for next-period policy & value inside ``do_egm_step()`` again instead of using dictionaries. To do so, pass in next-period policy & value numpy.ndarrays as arguments
- Compute continuation value, i.e. expected value, internally given log-sum formula