### PR TITLE
Save arrays in backward induction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Files
 .pyc
 .txt
+.npy
 
 
 src/dcegm/_version.py

--- a/src/dcegm/final_period.py
+++ b/src/dcegm/final_period.py
@@ -60,35 +60,3 @@ def solve_final_period(
         final_policy,
         marginal_utilities_choices,
     )
-
-
-def save_final_period_solution(
-    value_container: jnp.ndarray,
-    endog_grid_container: jnp.ndarray,
-    policy_container: jnp.ndarray,
-    idx_state_choices_final_period: jnp.ndarray,
-    value_final_period: jnp.ndarray,
-    endog_grid_final_period: jnp.ndarray,
-    policy_final_period: jnp.ndarray,
-    num_income_shock_draws: jnp.ndarray,
-    num_wealth_grid_points: jnp.ndarray,
-) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
-    """Saves the final period solution to the containers.
-
-    Soon this will be saved to disc.
-
-    """
-    # Choose which draw we take for policy and value function as those are note saved
-    # with respect to the draws
-    middle_of_draws = int(num_income_shock_draws + 1 / 2)
-    value_container[
-        idx_state_choices_final_period, ..., :num_wealth_grid_points
-    ] = value_final_period[:, :, middle_of_draws]
-    endog_grid_container[
-        idx_state_choices_final_period, ..., :num_wealth_grid_points
-    ] = endog_grid_final_period[:, :, middle_of_draws]
-    policy_container[
-        idx_state_choices_final_period, ..., :num_wealth_grid_points
-    ] = policy_final_period[:, :, middle_of_draws]
-
-    return value_container, endog_grid_container, policy_container

--- a/src/dcegm/interpolation.py
+++ b/src/dcegm/interpolation.py
@@ -11,10 +11,11 @@ def interpolate_and_calc_marginal_utilities(
     choice: int,
     next_period_wealth: jnp.ndarray,
     endog_grid_child_state_choice: jnp.array,
-    choice_policies_child_state_choice: jnp.ndarray,
-    choice_values_child_state_choice: jnp.ndarray,
+    policy_child_state_choice: jnp.ndarray,
+    value_child_state_choice: jnp.ndarray,
 ):
     """Interpolate marginal utilities.
+
     Args:
         compute_marginal_utility (callable): User-defined function to compute the
             agent's marginal utility. The input ```params``` is already partialled in.
@@ -39,7 +40,6 @@ def interpolate_and_calc_marginal_utilities(
         - marg_utils (float): Interpolated marginal utility function.
         - value_interp (float): Interpolated value function.
 
-
     """
     ind_high, ind_low = get_index_high_and_low(
         x=endog_grid_child_state_choice, x_new=next_period_wealth
@@ -51,17 +51,17 @@ def interpolate_and_calc_marginal_utilities(
         ),
         in_axes=(0, 0, 0, 0, 0, 0, 0, None, None, None, None, None),
     )(
-        choice_policies_child_state_choice[ind_high],
-        choice_values_child_state_choice[ind_high],
+        policy_child_state_choice[ind_high],
+        value_child_state_choice[ind_high],
         endog_grid_child_state_choice[ind_high],
-        choice_policies_child_state_choice[ind_low],
-        choice_values_child_state_choice[ind_low],
+        policy_child_state_choice[ind_low],
+        value_child_state_choice[ind_low],
         endog_grid_child_state_choice[ind_low],
         next_period_wealth,
         compute_value,
         compute_marginal_utility,
         endog_grid_child_state_choice[1],
-        choice_values_child_state_choice[0],
+        value_child_state_choice[0],
         choice,
     )
 

--- a/src/dcegm/pre_processing.py
+++ b/src/dcegm/pre_processing.py
@@ -158,58 +158,6 @@ def calc_current_value(
     return value
 
 
-def create_multi_dim_arrays(
-    state_choice_space: np.ndarray,
-    options: Dict[str, int],
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Create multi-dimensional arrays for endogenous grid, policy and value function.
-
-    We include one additional grid point (n_grid_wealth + 1) to M,
-    since we want to set the first position (j=0) to M_t = 0 for all time
-    periods.
-
-    Moreover, we add 10% extra space filled with nans, since, in the upper
-    envelope step, the endogenous wealth grid might be augmented to the left
-    in order to accurately describe potential non-monotonicities (and hence
-    discontinuities) near the start of the grid.
-
-
-    Note that, in the Upper Envelope step, we drop suboptimal points from the original
-    grid and add new ones (kink points as well as the corresponding interpolated values
-    of the policy and value functions).
-
-    Args:
-        state_space (np.ndarray): Collection of all possible state and choice
-            combinations.
-        options (dict): Options dictionary.
-
-    Returns:
-        tuple:
-
-        - endog_grid_container (np.ndarray): "Empty" 3d np.ndarray storing the
-            endogenous grid for each state and each discrete choice.
-            Has shape [n_states, n_discrete_choices, 1.1 * n_grid_wealth].
-        - policy_container (np.ndarray): "Empty" 3d np.ndarray storing the
-            choice-specific policy function for each state and each discrete choice
-            Has shape [n_states, n_discrete_choices, 1.1 * n_grid_wealth].
-        - value_container (np.ndarray): "Empty" 3d np.ndarray storing the
-            choice-specific value functions for each state and each discrete choice.
-            Has shape [n_states, n_discrete_choices, 1.1 * n_grid_wealth].
-
-    """
-    n_grid_wealth = options["grid_points_wealth"]
-    n_state_choice_combs = state_choice_space.shape[0]
-
-    endog_grid_container = np.empty((n_state_choice_combs, int(1.1 * n_grid_wealth)))
-    policy_container = np.empty((n_state_choice_combs, int(1.1 * n_grid_wealth)))
-    value_container = np.empty((n_state_choice_combs, int(1.1 * n_grid_wealth)))
-    endog_grid_container[:] = np.nan
-    policy_container[:] = np.nan
-    value_container[:] = np.nan
-
-    return endog_grid_container, policy_container, value_container
-
-
 def _return_policy_and_value(
     endog_grid, policy, value, expected_value_zero_savings, **kwargs
 ):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -104,14 +104,15 @@ def test_benchmark_models(
 
     # need to loop over period? Isn't state_choice space enough?
     for period in range(23, -1, -1):
-        state_choices_idxs_period = np.where(state_choice_space[:, 0] == period)[0]
+        idxs_state_choice_combs = np.where(state_choice_space[:, 0] == period)[0]
 
-        for state_choice_idx in state_choices_idxs_period:
-            endog_grid_got = np.load(f"endog_grid_{state_choice_idx}.npy")
-            policy_got = np.load(f"policy_{state_choice_idx}.npy")
-            value_got = np.load(f"value_{state_choice_idx}.npy")
+        endog_grid_got = np.load(f"endog_grid_{period}.npy")
+        policy_got = np.load(f"policy_{period}.npy")
+        value_got = np.load(f"value_{period}.npy")
 
-            choice = state_choice_space[state_choice_idx, -1]
+        for state_choice_idx, state_choice_vec in enumerate(idxs_state_choice_combs):
+            choice = state_choice_space[state_choice_vec, -1]
+
             if model == "deaton":
                 policy_expec = policy_expected[period, choice]
                 value_expec = value_expected[period, choice]
@@ -135,9 +136,9 @@ def test_benchmark_models(
                 value_calc_interp,
             ) = interpolate_policy_and_value_on_wealth_grid(
                 begin_of_period_wealth=wealth_grid_to_test,
-                endog_wealth_grid=endog_grid_got,
-                policy_grid=policy_got,
-                value_grid=value_got,
+                endog_wealth_grid=endog_grid_got[state_choice_idx],
+                policy_grid=policy_got[state_choice_idx],
+                value_grid=value_got[state_choice_idx],
             )
 
             aaae(policy_expec_interp, policy_calc_interp)

--- a/tests/test_two_period_model.py
+++ b/tests/test_two_period_model.py
@@ -175,7 +175,7 @@ def input_data():
         "marginal_utility": marginal_utility,
     }
 
-    endog_grid, policy, _ = solve_dcegm(
+    solve_dcegm(
         params,
         options,
         utility_functions,
@@ -188,8 +188,7 @@ def input_data():
     out = {}
     out["params"] = params
     out["options"] = options
-    out["endog_grid"] = endog_grid
-    out["policy"] = policy
+
     return out
 
 
@@ -226,8 +225,10 @@ def test_two_period(input_data, wealth_idx, state_idx):
 
     for idx_state_choice in idxs_state_choice_combs:
         choice_in_period_1 = state_choice_space[idx_state_choice][-1]
-        policy = input_data["policy"][idx_state_choice]
-        wealth = input_data["endog_grid"][idx_state_choice, wealth_idx + 1]
+
+        wealth = np.load(f"endog_grid_{idx_state_choice}.npy")[wealth_idx + 1]
+        policy = np.load(f"policy_{idx_state_choice}.npy")
+
         if ~np.isnan(wealth) and wealth > 0:
             initial_cond["wealth"] = wealth
 

--- a/tests/test_two_period_model.py
+++ b/tests/test_two_period_model.py
@@ -223,14 +223,17 @@ def test_two_period(input_data, wealth_idx, state_idx):
     idxs_state_choice_combs = reshape_state_choice_vec_to_mat[state_idx]
     initial_cond["health"] = state[-1]
 
-    for idx_state_choice in idxs_state_choice_combs:
-        choice_in_period_1 = state_choice_space[idx_state_choice][-1]
+    endog_grid_period = np.load(f"endog_grid_{state[0]}.npy")
+    policy_period = np.load(f"policy_{state[0]}.npy")
 
-        wealth = np.load(f"endog_grid_{idx_state_choice}.npy")[wealth_idx + 1]
-        policy = np.load(f"policy_{idx_state_choice}.npy")
+    for state_choice_idx in idxs_state_choice_combs:
+        choice_in_period_1 = state_choice_space[state_choice_idx][-1]
 
-        if ~np.isnan(wealth) and wealth > 0:
-            initial_cond["wealth"] = wealth
+        endog_grid = endog_grid_period[state_choice_idx, wealth_idx + 1]
+        policy = policy_period[state_choice_idx]
+
+        if ~np.isnan(endog_grid) and endog_grid > 0:
+            initial_cond["wealth"] = endog_grid
 
             cons_calc = policy[wealth_idx + 1]
             diff = euler_rhs(


### PR DESCRIPTION
Save wealth grid, policy, and value function to disc. Before the period and state-choice specific arrays were stored in a multi-dimensional container array.