### PR TITLE
Remove temporay arrays after pytest session

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import sys
 from pathlib import Path
@@ -32,3 +33,16 @@ def load_example_model():
 
 def pytest_sessionstart(session):  # noqa: ARG001
     config.update("jax_enable_x64", val=True)
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_sessionfinish(session, exitstatus):
+    # Get the current working directory
+    cwd = os.getcwd()
+
+    # Search for .npy files in the current directory
+    npy_files = glob.glob(os.path.join(cwd, "*.npy"))
+
+    # Delete all the .npy files
+    for file in npy_files:
+        os.remove(file)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,9 +40,10 @@ def pytest_sessionfinish(session, exitstatus):
     # Get the current working directory
     cwd = os.getcwd()
 
-    # Search for .npy files in the current directory
-    npy_files = glob.glob(os.path.join(cwd, "*.npy"))
+    # Search for .npy files that match the naming pattern
+    pattern = os.path.join(cwd, "[endog_grid_, policy_, value_]*.npy")
+    npy_files = glob.glob(pattern)
 
-    # Delete all the .npy files
+    # Delete the matching .npy files
     for file in npy_files:
         os.remove(file)


### PR DESCRIPTION
Every time ```solve_dcegm``` is called, the period-specific ```endog_grid```, ```policy```, and ```value``` arrays are saved to disc. Make sure that pytest auto-deletes these files after each test session. 