### PR TITLE
Save jax arrays to disc inside jitted function

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Python implementation of the Discrete-Continuous Endogenous Grid Method (DC-EGM)
 solving dynamic stochastic lifecycle models of continuous (e.g. consumption-savings) and
 additional discrete choices.
 
-The solution algorithm employs an extension to the Fast Upper-Envelope Scan (FUES),
-based on Dobrescu & Shanker (2022).
+The solution algorithm employs an extension of the Fast Upper-Envelope Scan (FUES) from
+Dobrescu & Shanker (2022).
 
 ## References
 

--- a/tests/sandbox/jax_timeit.ipynb
+++ b/tests/sandbox/jax_timeit.ipynb
@@ -2,19 +2,10 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 1,
    "id": "597c9fcc",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%load_ext autoreload\n",
     "\n",
@@ -27,10 +18,10 @@
     "import os\n",
     "from dcegm.solve import solve_dcegm, get_solve_function\n",
     "from functools import partial\n",
-    "from dcegm.fast_upper_envelope import fast_upper_envelope\n",
+    "from dcegm.fast_upper_envelope import fast_upper_envelope, fast_upper_envelope_wrapper\n",
     "import pandas as pd\n",
     "import yaml\n",
-    "from dcegm.pre_processing import convert_params_to_dict\n",
+    "from dcegm.pre_processing import convert_params_to_dict, get_partial_functions\n",
     "import numpy as np\n",
     "\n",
     "\n",
@@ -105,6 +96,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "7ace46a1-3294-4eb1-b868-020b10b7cb36",
+   "metadata": {},
+   "source": [
+    "# Timeit overall solve"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "id": "9a8ac104-b90f-4663-b482-13eabbc0ea90",
@@ -119,33 +118,26 @@
     }
    ],
    "source": [
+    "model = \"retirement_taste_shocks\"\n",
     "TEST_RESOURCES_DIR = \"../resources/\"\n",
+    "\n",
     "params = pd.read_csv(\n",
-    "    TEST_RESOURCES_DIR + \"retirement_taste_shocks.csv\", index_col=[\"category\", \"name\"]\n",
+    "    TEST_RESOURCES_DIR + f\"{model}.csv\", index_col=[\"category\", \"name\"]\n",
     ")\n",
-    "options = yaml.safe_load(\n",
-    "    open(TEST_RESOURCES_DIR + \"retirement_taste_shocks.yaml\", \"rb\")\n",
-    ")\n",
+    "options = yaml.safe_load(open(TEST_RESOURCES_DIR + f\"{model}.yaml\", \"rb\"))\n",
     "options[\"n_exog_states\"] = 1\n",
+    "# options[\"n_periods\"] = 3\n",
     "exog_savings_grid = jnp.linspace(0, options[\"max_wealth\"], options[\"n_grid_points\"])"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "7ace46a1-3294-4eb1-b868-020b10b7cb36",
-   "metadata": {},
-   "source": [
-    "# Timeit"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "fe4de387-c44e-44a1-b4cb-a7ab6dabf57d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "backwards_jit = get_solve_function(\n",
+    "backward_jit = get_solve_function(\n",
     "    options=options,\n",
     "    exog_savings_grid=exog_savings_grid,\n",
     "    utility_functions=utility_functions,\n",
@@ -158,26 +150,61 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "9118060d-c787-4320-bee6-6ec52fdb8750",
+   "execution_count": 7,
+   "id": "b5487d6f",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "58.8 ms ± 2.36 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "118 ms ± 2.42 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
    "source": [
-    "backwards_jit(params).block_until_ready()\n",
-    "%timeit backwards_jit(params).block_until_ready()"
+    "jax.block_until_ready(backward_jit(params))\n",
+    "%timeit jax.block_until_ready(backward_jit(params))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
+   "id": "2e25dd71",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "119 ms ± 3.3 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "backward_jit(params)\n",
+    "%timeit backward_jit(params)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "664ed16e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5cbdf6a-45da-4fe2-9226-0ba58260f2ed",
+   "metadata": {},
+   "source": [
+    "# Timeit upper envelope"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "id": "2e56bf97",
    "metadata": {},
    "outputs": [],
@@ -187,22 +214,38 @@
     ")\n",
     "value_egm = jnp.array(\n",
     "    np.genfromtxt(TEST_RESOURCES_DIR + \"period_tests/val10.csv\", delimiter=\",\")\n",
+    ")\n",
+    "params_dict = convert_params_to_dict(params)\n",
+    "(\n",
+    "    compute_utility,\n",
+    "    compute_marginal_utility,\n",
+    "    compute_inverse_marginal_utility,\n",
+    "    compute_value,\n",
+    "    compute_next_period_wealth,\n",
+    "    compute_upper_envelope,\n",
+    "    transition_vector_by_state,\n",
+    ") = get_partial_functions(\n",
+    "    options,\n",
+    "    user_utility_functions=utility_functions,\n",
+    "    user_budget_constraint=budget_constraint,\n",
+    "    exogenous_transition_function=get_transition_matrix_by_state,\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 14,
    "id": "1acaf6c9",
    "metadata": {},
    "outputs": [],
    "source": [
+    "# test_upp_env = jit(partial(fast_upper_envelope_wrapper, choice=1, params=params_dict, compute_value=compute_value))\n",
     "test_upp_env = jit(partial(fast_upper_envelope, num_iter=int(value_egm.shape[1])))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 15,
    "id": "debf8987",
    "metadata": {},
    "outputs": [
@@ -210,7 +253,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.55 ms ± 23.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "2.5 ms ± 45.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -225,9 +268,75 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b411e458-3419-4721-9077-e0989151878c",
+   "metadata": {},
+   "source": [
+    "# Timing of jax.lax.scan"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "a0d778e8-c228-44d5-9120-8c2a07f5dbbd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def body_1(carry, _it_step):\n",
+    "    new_carry = carry + 1.5\n",
+    "    return new_carry, new_carry\n",
+    "\n",
+    "\n",
+    "def body_2(carry, _it_step):\n",
+    "    new_carry = carry + 1\n",
+    "    return new_carry, new_carry\n",
+    "\n",
+    "test_body_1 = jit(lambda start: jax.lax.scan(body_1, start, xs=None, length=5000))\n",
+    "test_body_2 = jit(lambda start: jax.lax.scan(body_2, start, xs=None, length=5000))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "af5ee5a4-5762-4af4-80d9-275a080011fc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "23.3 µs ± 184 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "test_body_1(1.0)\n",
+    "%timeit test_body_1(1.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "ca493800-af2e-47e8-9011-5697782384f7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "12 µs ± 59.4 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "test_body_2(1)\n",
+    "%timeit test_body_2(1)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d3d8a346-f977-46ac-8767-f180d0285661",
+   "id": "29f832b6-6f30-4be6-9148-be932ce44e03",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -87,7 +87,7 @@ def test_benchmark_models(
     if params.loc[("utility_function", "theta"), "value"] == 1:
         utility_functions["utility"] = utiility_func_log_crra
 
-    result_dict = solve_dcegm(
+    solve_dcegm(
         params,
         options,
         exog_savings_grid=exog_savings_grid,
@@ -103,14 +103,13 @@ def test_benchmark_models(
     )
     value_expected = pickle.load((TEST_RESOURCES_DIR / f"value_{model}.pkl").open("rb"))
 
-    # need to loop over period? Isn't state_choice space enough?
     for period in range(23, -1, -1):
         idxs_state_choice_combs = jnp.where(state_choice_space[:, 0] == period)[0]
 
-        endog_grid_got = result_dict[period]["endog_grid"]
-        policy_left_got = result_dict[period]["policy_left"]
-        policy_right_got = result_dict[period]["policy_right"]
-        value_got = result_dict[period]["value"]
+        endog_grid_got = jnp.load(f"endog_grid_{period}.npy")
+        policy_left_got = jnp.load(f"policy_left_{period}.npy")
+        policy_right_got = jnp.load(f"policy_right_{period}.npy")
+        value_got = jnp.load(f"value_{period}.npy")
 
         for state_choice_idx, state_choice_vec in enumerate(idxs_state_choice_combs):
             choice = state_choice_space[state_choice_vec, -1]

--- a/tests/test_two_period_model.py
+++ b/tests/test_two_period_model.py
@@ -177,7 +177,7 @@ def input_data():
 
     exog_savings_grid = np.linspace(0, options["max_wealth"], options["n_grid_points"])
 
-    result_dict = solve_dcegm(
+    solve_dcegm(
         params,
         options,
         exog_savings_grid=exog_savings_grid,
@@ -191,8 +191,6 @@ def input_data():
     out = {}
     out["params"] = params
     out["options"] = options
-    out["endog_grid"] = result_dict[0]["endog_grid"]
-    out["policy_left"] = result_dict[0]["policy_left"]
 
     return out
 
@@ -228,8 +226,8 @@ def test_two_period(input_data, wealth_idx, state_idx):
     idxs_state_choice_combs = reshape_state_choice_vec_to_mat[state_idx]
     initial_cond["health"] = state[-1]
 
-    endog_grid_period = input_data["endog_grid"]
-    policy_period = input_data["policy_left"]
+    endog_grid_period = np.load(f"endog_grid_{state[0]}.npy")
+    policy_period = np.load(f"policy_left_{state[0]}.npy")
 
     for state_choice_idx in idxs_state_choice_combs:
         choice_in_period_1 = state_choice_space[state_choice_idx][-1]


### PR DESCRIPTION
Save ```jax.ndarrays``` to disc inside jitted backward induction. The arrays for endog_grid, policy, and value are saved to disc in each period rather than being added to a results ```dict```. This increases performance.

As the standard ```jax``` library does not allow for impure functions during jit compilation (e.g. functions **with side-effects** such as saving data to disc), we use ```jax.experimental.io_callback()```. See the [documentation](https://jax.readthedocs.io/en/latest/_autosummary/jax.experimental.io_callback.html#jax.experimental.io_callback), an [example](https://jax.readthedocs.io/en/latest/notebooks/external_callbacks.html), and the [discussion here](https://github.com/google/jax/discussions/3766).

