### PR TITLE
Rewrote last for loops in fast upper envelope to scan functions

### DIFF
--- a/src/dcegm/fast_upper_envelope.py
+++ b/src/dcegm/fast_upper_envelope.py
@@ -13,6 +13,7 @@ from typing import Tuple
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 from dcegm.math_funcs import calc_gradient
 from dcegm.math_funcs import calc_intersection_and_extrapolate_policy
 from jax import vmap
@@ -74,7 +75,7 @@ def fast_upper_envelope_wrapper(
             containing refined state- and choice-specific value function.
 
     """
-    min_wealth_grid = jnp.min(endog_grid)
+    min_wealth_grid = np.min(endog_grid)
     # These tuning parameters should be set outside. Don't want to touch solve.py now
     points_to_add = len(endog_grid) // 10
     num_iter = int(1.2 * value.shape[0])
@@ -542,7 +543,7 @@ def _forward_scan(
         - idx_on_same_value (int): Index of next point on the value function.
 
     """
-    indexes_to_scan = idx_to_inspect + jnp.arange(1, n_points_to_scan + 1, dtype=int)
+    indexes_to_scan = idx_to_inspect + np.arange(1, n_points_to_scan + 1, dtype=int)
     (
         grad_next_on_same_value,
         idx_on_same_value,
@@ -601,7 +602,7 @@ def _backward_scan(
             previous point on the same value function.
 
     """
-    indexes_to_scan = idx_to_inspect - jnp.arange(1, n_points_to_scan + 1, dtype=int)
+    indexes_to_scan = idx_to_inspect - np.arange(1, n_points_to_scan + 1, dtype=int)
     (
         grad_before_on_same_value,
         idx_point_before_on_same_value,

--- a/src/dcegm/fast_upper_envelope.py
+++ b/src/dcegm/fast_upper_envelope.py
@@ -631,6 +631,38 @@ def back_and_forward_scan_wrapper(
     indexes_to_scan,
     jump_thresh,
 ):
+    """Wrapper function to execute the backwards and forward scan.
+
+    Args:
+        endog_grid_to_calculate_gradient (float): The endogenous grid point to calculate
+            the gradient from.
+        value_to_calculate_gradient (float): The value function point to calculate the
+            gradient from.
+        endog_grid_to_scan_from (float): The endogenous grid point to scan from. We want
+            to find the grid point which is on the same value function segment as the
+            point we scan from.
+        policy_to_scan_from (float): The policy function point to scan from. We want to
+            find the grid point which is on the same value function segment as the point
+            we scan from.
+        endog_grid (np.ndarray): 1d array of shape (n_grid_wealth,) containing the
+            unrefined endogenous wealth grid.
+        value (np.ndarray): 1d array of shape (n_grid_wealth,) containing the
+            unrefined value correspondence.
+        policy (np.ndarray): 1d array of shape (n_grid_wealth,) containing the
+            unrefined policy correspondence.
+        indexes_to_scan (np.ndarray): 1d array of shape (n_points_to_scan,) containing
+            the indexes to scan.
+        jump_thresh (float): Threshold for the jump in the value function.
+
+
+    Returns:
+        tuple:
+
+        - grad_we_search_for (float): The gradient we search for.
+        - idx_on_same_value (int): The index of the point on the same value function
+            segment as the point we scan from.
+
+    """
     # Prepare body function by partialing in, everything except carry and counter
     partial_body = partial(
         back_and_forward_scan_body,
@@ -686,6 +718,38 @@ def back_and_forward_scan_body(
     policy,
     jump_thresh,
 ):
+    """The scan body to be executed at each iteration of the backwards and forward scan
+    function.
+
+    Args:
+        carry (tuple): The carry value passed from the previous iteration. This is a
+            tuple containing the variables that are updated in each iteration.
+        current_scaned_index (int): The current index to be scanned.
+        endog_grid_to_calculate_gradient (float): The endogenous grid point to calculate
+            the gradient from.
+        value_to_calculate_gradient (float): The value function point to calculate the
+            gradient from.
+        endog_grid_to_scan_from (float): The endogenous grid point to scan from. We want
+            to find the grid point which is on the same value function segment as the
+            point we scan from.
+        policy_to_scan_from (float): The policy function point to scan from. We want to
+            find the grid point which is on the same value function segment as the point
+            we scan from.
+        endog_grid (np.ndarray): 1d array of shape (n_grid_wealth,) containing the
+            unrefined endogenous wealth grid.
+        value (np.ndarray): 1d array of shape (n_grid_wealth,) containing the
+            unrefined value correspondence.
+        policy (np.ndarray): 1d array of shape (n_grid_wealth,) containing the
+            unrefined policy correspondence.
+        jump_thresh (float): Threshold for the jump in the value function.
+
+    Returns:
+        tuple:
+
+        - carry (tuple): The updated carry value passed to the next iteration.
+        - None: Dummy value to be returned.
+
+    """
     (
         found_value_already,
         idx_on_same_value,

--- a/src/dcegm/fast_upper_envelope.py
+++ b/src/dcegm/fast_upper_envelope.py
@@ -626,6 +626,7 @@ def _backward_scan(
 
     """
 
+    # Initialize starting values
     found_value_before_already = False
     idx_point_before_on_same_value = 0
     grad_before_on_same_value = 0.0
@@ -641,19 +642,21 @@ def _backward_scan(
         jump_thresh=jump_thresh,
     )
 
+    # These values will be updated each iteration.
     carry_to_update = (
         found_value_before_already,
         idx_point_before_on_same_value,
         grad_before_on_same_value,
     )
 
-    carry = jax.lax.fori_loop(1, n_points_to_scan + 1, partial_body, carry_to_update)
+    # Execute backward scan.
+    result = jax.lax.fori_loop(1, n_points_to_scan + 1, partial_body, carry_to_update)
 
     (
         found_value_before_already,
         idx_point_before_on_same_value,
         grad_before_on_same_value,
-    ) = carry
+    ) = result
 
     return (
         grad_before_on_same_value,

--- a/tests/sandbox/jax_timeit_and_profiler.ipynb
+++ b/tests/sandbox/jax_timeit_and_profiler.ipynb
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "id": "86a3197a",
    "metadata": {},
    "outputs": [],
@@ -70,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "6b1cbdc3",
    "metadata": {},
    "outputs": [
@@ -178,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "id": "246489e0",
    "metadata": {},
    "outputs": [],
@@ -194,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 27,
    "id": "b0a71a55",
    "metadata": {},
    "outputs": [],
@@ -205,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 28,
    "id": "9e675bb0",
    "metadata": {},
    "outputs": [
@@ -213,7 +213,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3.98 ms ± 42.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "2.5 ms ± 43.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],

--- a/tests/sandbox/jax_timeit_and_profiler.ipynb
+++ b/tests/sandbox/jax_timeit_and_profiler.ipynb
@@ -194,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 32,
    "id": "b0a71a55",
    "metadata": {},
    "outputs": [],
@@ -205,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 33,
    "id": "9e675bb0",
    "metadata": {},
    "outputs": [
@@ -213,7 +213,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.5 ms ± 43.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "2.54 ms ± 51.2 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],


### PR DESCRIPTION
This PR optimizes the fast upper envelope functions further for jax. Even though it didn't change much of the runtime, it cuts compilation time in half.