### PR TITLE
Implement test for options

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,15 +104,15 @@ def params_and_options_exog_ltc():
         },
         "state_space": {
             "n_periods": 2,
-            "choices": np.arange(2),
+            "choices": 2,
             "endogenous_states": {
-                "married": [0, 1],
+                "married": 2,
             },
             "continuous_states": {
                 "wealth": np.linspace(0, 50, WEALTH_GRID_POINTS),
             },
             "exogenous_processes": {
-                "ltc": {"transition": prob_exog_ltc, "states": [0, 1]},
+                "ltc": {"transition": prob_exog_ltc, "states": 2},
             },
         },
     }
@@ -149,16 +149,16 @@ def params_and_options_exog_ltc_and_job_offer():
         },
         "state_space": {
             "n_periods": 2,
-            "choices": np.arange(2),
+            "choices": 2,
             "endogenous_states": {
-                "married": [0, 1],
+                "married": 2,
             },
             "continuous_states": {
                 "wealth": np.linspace(0, 50, WEALTH_GRID_POINTS),
             },
             "exogenous_processes": {
-                "ltc": {"transition": prob_exog_ltc, "states": [0, 1]},
-                "job_offer": {"transition": prob_exog_job_offer, "states": [0, 1]},
+                "ltc": {"transition": prob_exog_ltc, "states": 2},
+                "job_offer": {"transition": prob_exog_job_offer, "states": 2},
             },
         },
     }

--- a/tests/test_biased_sim.py
+++ b/tests/test_biased_sim.py
@@ -37,9 +37,9 @@ def marriage_transition(married, options):
 def state_space_options():
     state_space_options_sol = {
         "n_periods": 5,
-        "choices": np.arange(2),
+        "choices": 2,
         "endogenous_states": {
-            "married": np.arange(2, dtype=int),
+            "married": 2,
         },
         "continuous_states": {
             "wealth": np.arange(0, 100, 5, dtype=float),
@@ -48,10 +48,10 @@ def state_space_options():
 
     state_space_options_sim = {
         "n_periods": 5,
-        "choices": np.arange(2),
+        "choices": 2,
         "exogenous_processes": {
             "married": {
-                "states": np.arange(2, dtype=int),
+                "states": 2,
                 "transition": marriage_transition,
             },
         },

--- a/tests/test_changing_choice_set.py
+++ b/tests/test_changing_choice_set.py
@@ -102,16 +102,16 @@ def test_model():
         },
         "state_space": {
             "n_periods": 5,
-            "choices": np.arange(3),
+            "choices": 3,
             "endogenous_states": {
-                "experience": np.arange(5),
+                "experience": 5,
             },
             "continuous_states": {
                 "wealth": np.linspace(0, 500, 100),
             },
             "exogenous_processes": {
-                "health": {"transition": prob_health, "states": [0, 1]},
-                "partner": {"transition": prob_partner, "states": [0, 1]},
+                "health": {"transition": prob_health, "states": 2},
+                "partner": {"transition": prob_partner, "states": 2},
             },
         },
     }

--- a/tests/test_discrete_versus_continuous_experience.py
+++ b/tests/test_discrete_versus_continuous_experience.py
@@ -60,11 +60,9 @@ def test_setup():
 
     state_space_options = {
         "n_periods": N_PERIODS,
-        "choices": np.arange(
-            N_DISCRETE_CHOICES,
-        ),
+        "choices": N_DISCRETE_CHOICES,
         "endogenous_states": {
-            "experience": np.arange(N_PERIODS + MAX_INIT_EXPERIENCE),
+            "experience": N_PERIODS + MAX_INIT_EXPERIENCE,
         },
         "continuous_states": {
             "wealth": jnp.linspace(

--- a/tests/test_exog_processes.py
+++ b/tests/test_exog_processes.py
@@ -120,9 +120,9 @@ def test_exog_processes(
         },
         "state_space": {
             "n_periods": 2,
-            "choices": np.arange(2),
+            "choices": 2,
             "endogenous_states": {
-                "married": [0, 1],
+                "married": 2,
             },
             "continuous_states": {
                 "wealth": np.linspace(0, 50, 100),
@@ -130,19 +130,19 @@ def test_exog_processes(
             "exogenous_processes": {
                 "health_mother": {
                     "transition": prob_exog_health_mother,
-                    "states": [0, 1, 2],
+                    "states": 3,
                 },
                 "health_father": {
                     "transition": prob_exog_health_father,
-                    "states": [0, 1, 2],
+                    "states": 3,
                 },
                 "health_child": {
                     "transition": prob_exog_health_child,
-                    "states": [0, 1],
+                    "states": 2,
                 },
                 "health_grandma": {
                     "transition": prob_exog_health_grandma,
-                    "states": [0, 1],
+                    "states": 2,
                 },
             },
         },

--- a/tests/test_options_tests.py
+++ b/tests/test_options_tests.py
@@ -10,9 +10,9 @@ def valid_options():
     return {
         "state_space": {
             "n_periods": 5,
-            "choices": [1, 2, 3],
+            "choices": 3,
             "endogenous_states": {
-                "education": np.arange(2, dtype=int),
+                "education": 2,
             },
             "continuous_states": {
                 "wealth": np.linspace(0, 10, 11),
@@ -21,11 +21,13 @@ def valid_options():
             "exogenous_processes": {
                 "health": {
                     "transition": lambda x: x,
-                    "states": np.arange(3, dtype=int),
+                    "states": 3,
                 },
             },
         },
-        "model_params": {},
+        "model_params": {
+            "n_choices": 3,
+        },
         "tuning_params": {},
     }
 
@@ -71,20 +73,24 @@ def test_invalid_n_periods_value(valid_options):
 @pytest.mark.parametrize(
     "choices, expected_array",
     [
-        ([1, 2, 3], np.array([1, 2, 3], dtype=np.uint8)),
-        (5, np.array([5], dtype=np.uint8)),
-        (np.array([1, 2, 3]), np.array([1, 2, 3], dtype=np.uint8)),
+        (3, np.array([0, 1, 2], dtype=np.uint8)),
+        (5, np.arange(5, dtype=np.uint8)),
     ],
 )
 def test_valid_choices_conversion(valid_options, choices, expected_array):
     valid_options["state_space"]["choices"] = choices
+    if choices == 5:
+        valid_options["model_params"]["n_choices"] = 5
     options = check_options_and_set_defaults(valid_options)
     np.testing.assert_array_equal(options["state_space"]["choices"], expected_array)
 
 
 def test_invalid_choices_type(valid_options):
     valid_options["state_space"]["choices"] = "not_a_valid_type"
-    with pytest.raises(ValueError, match="Choices must be a list or an integer."):
+    with pytest.raises(ValueError, match="choices must be an integer."):
+        check_options_and_set_defaults(valid_options)
+    valid_options["state_space"]["choices"] = [1, 2, 3]
+    with pytest.raises(ValueError, match="choices must be an integer."):
         check_options_and_set_defaults(valid_options)
 
 
@@ -102,11 +108,135 @@ def test_invalid_model_params_type(valid_options):
         check_options_and_set_defaults(valid_options)
 
 
-# maybe also check this in the check_options_and_set_defaults function
+def test_invalid_endogenous_states_type(valid_options):
+    valid_options["state_space"]["endogenous_states"] = "not_a_dict"
+    with pytest.raises(
+        ValueError,
+        match="endogenous_states specified in the options must be a dictionary.",
+    ):
+        check_options_and_set_defaults(valid_options)
+
+
+def test_invalid_endogenous_state_value_type(valid_options):
+    valid_options["state_space"]["endogenous_states"]["education"] = "not_an_int"
+    with pytest.raises(ValueError, match="education value must be an integer."):
+        check_options_and_set_defaults(valid_options)
+
+
+def test_invalid_exogenous_processes_type(valid_options):
+    valid_options["state_space"]["exogenous_processes"] = "not_a_dict"
+    with pytest.raises(ValueError, match="Exogenous processes must be a dictionary."):
+        check_options_and_set_defaults(valid_options)
+
+
+def test_invalid_exogenous_process_structure(valid_options):
+    valid_options["state_space"]["exogenous_processes"]["health"] = "not_a_dict"
+    with pytest.raises(
+        ValueError,
+        match="health value must be a dictionary in the options exogenous processes dictionary",
+    ):
+        check_options_and_set_defaults(valid_options)
+
+
+def test_missing_transition_in_exogenous_process(valid_options):
+    del valid_options["state_space"]["exogenous_processes"]["health"]["transition"]
+    with pytest.raises(
+        ValueError,
+        match="health must contain a transition function in the options exogenous processes dictionary.",
+    ):
+        check_options_and_set_defaults(valid_options)
+
+
+def test_missing_states_in_exogenous_process(valid_options):
+    del valid_options["state_space"]["exogenous_processes"]["health"]["states"]
+    with pytest.raises(
+        ValueError,
+        match="health must contain states in the options exogenous processes dictionary.",
+    ):
+        check_options_and_set_defaults(valid_options)
+
+
+def test_invalid_states_type_in_exogenous_process(valid_options):
+    valid_options["state_space"]["exogenous_processes"]["health"][
+        "states"
+    ] = "not_an_int"
+    with pytest.raises(
+        ValueError,
+        match="health states must be an int in the options exogenous processes dictionary.",
+    ):
+        check_options_and_set_defaults(valid_options)
+
+
 def test_missing_continuous_states(valid_options):
     del valid_options["state_space"]["continuous_states"]
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError, match="State space must contain continuous states."):
         check_options_and_set_defaults(valid_options)
+
+
+def test_missing_wealth_in_continuous_states(valid_options):
+    del valid_options["state_space"]["continuous_states"]["wealth"]
+    with pytest.raises(ValueError, match="Continuous states must contain wealth."):
+        check_options_and_set_defaults(valid_options)
+
+
+def test_invalid_wealth_type(valid_options):
+    valid_options["state_space"]["continuous_states"]["wealth"] = "not_a_list_or_array"
+    with pytest.raises(
+        ValueError,
+        match="Wealth must be a list, numpy array or jax numpy array is .* instead.",
+    ):
+        check_options_and_set_defaults(valid_options)
+
+
+def test_invalid_continuous_state_type(valid_options):
+    valid_options["state_space"]["continuous_states"][
+        "experience"
+    ] = "not_a_list_or_array"
+    with pytest.raises(
+        ValueError,
+        match="experience must be a list, numpy array or jax numpy array is .* instead.",
+    ):
+        check_options_and_set_defaults(valid_options)
+
+
+def test_valid_endogenous_states_conversion(valid_options):
+    valid_options["state_space"]["endogenous_states"]["education"] = 3
+    options = check_options_and_set_defaults(valid_options)
+    np.testing.assert_array_equal(
+        options["state_space"]["endogenous_states"]["education"],
+        np.arange(3, dtype=np.uint8),
+    )
+
+
+def test_valid_exogenous_states_conversion(valid_options):
+    valid_options["state_space"]["exogenous_processes"]["health"]["states"] = 4
+    options = check_options_and_set_defaults(valid_options)
+    np.testing.assert_array_equal(
+        options["state_space"]["exogenous_processes"]["health"]["states"],
+        np.arange(4, dtype=np.uint8),
+    )
+
+
+def test_missing_n_choices_in_model_params(valid_options):
+    del valid_options["model_params"]["n_choices"]
+    options = check_options_and_set_defaults(valid_options)
+    assert (
+        options["model_params"]["n_choices"]
+        == options["state_space"]["choices"].shape[0]
+    )
+
+
+def test_mismatched_n_choices_warning(valid_options):
+    valid_options["model_params"]["n_choices"] = 2  # Intentionally mismatched
+    with pytest.warns(
+        UserWarning,
+        match="n_choices in the options model_params dictionary.*is not equal to the number of choices.*",
+    ):
+        options = check_options_and_set_defaults(valid_options)
+    assert (
+        options["model_params"]["n_choices"]
+        == options["state_space"]["choices"].shape[0]
+    )
 
 
 def test_tuning_params_defaults(valid_options):

--- a/tests/test_options_tests.py
+++ b/tests/test_options_tests.py
@@ -1,0 +1,11 @@
+from dcegm.pre_processing.setup_model import setup_model
+
+
+def test_n_periods():
+
+    test_model = setup_model(
+        options={"state_space": {"n_periods": 1}},
+        utility_functions={},
+        utility_functions_final_period={},
+        budget_constraint=lambda x: x,
+    )

--- a/tests/test_options_tests.py
+++ b/tests/test_options_tests.py
@@ -1,11 +1,133 @@
-from dcegm.pre_processing.setup_model import setup_model
+import numpy as np
+import pytest
+
+from dcegm.pre_processing.check_options import check_options_and_set_defaults
 
 
-def test_n_periods():
+@pytest.fixture
+def valid_options():
+    """Fixture providing a valid options dictionary."""
+    return {
+        "state_space": {
+            "n_periods": 5,
+            "choices": [1, 2, 3],
+            "endogenous_states": {
+                "education": np.arange(2, dtype=int),
+            },
+            "continuous_states": {
+                "wealth": np.linspace(0, 10, 11),
+                "experience": np.linspace(0, 5, 6),
+            },
+            "exogenous_processes": {
+                "health": {
+                    "transition": lambda x: x,
+                    "states": np.arange(3, dtype=int),
+                },
+            },
+        },
+        "model_params": {},
+        "tuning_params": {},
+    }
 
-    test_model = setup_model(
-        options={"state_space": {"n_periods": 1}},
-        utility_functions={},
-        utility_functions_final_period={},
-        budget_constraint=lambda x: x,
+
+def test_invalid_options_type():
+    with pytest.raises(ValueError, match="Options must be a dictionary."):
+        check_options_and_set_defaults([])
+
+
+def test_missing_state_space(valid_options):
+    del valid_options["state_space"]
+    with pytest.raises(
+        ValueError, match="Options must contain a state space dictionary."
+    ):
+        check_options_and_set_defaults(valid_options)
+
+
+def test_invalid_state_space_type():
+    with pytest.raises(ValueError, match="State space must be a dictionary."):
+        check_options_and_set_defaults({"state_space": "not_a_dict"})
+
+
+def test_missing_n_periods(valid_options):
+    del valid_options["state_space"]["n_periods"]
+    with pytest.raises(
+        ValueError, match="State space must contain the number of periods."
+    ):
+        check_options_and_set_defaults(valid_options)
+
+
+def test_invalid_n_periods_type(valid_options):
+    valid_options["state_space"]["n_periods"] = "not_an_int"
+    with pytest.raises(ValueError, match="Number of periods must be an integer."):
+        check_options_and_set_defaults(valid_options)
+
+
+def test_invalid_n_periods_value(valid_options):
+    valid_options["state_space"]["n_periods"] = 1
+    with pytest.raises(ValueError, match="Number of periods must be greater than 1."):
+        check_options_and_set_defaults(valid_options)
+
+
+@pytest.mark.parametrize(
+    "choices, expected_array",
+    [
+        ([1, 2, 3], np.array([1, 2, 3], dtype=np.uint8)),
+        (5, np.array([5], dtype=np.uint8)),
+        (np.array([1, 2, 3]), np.array([1, 2, 3], dtype=np.uint8)),
+    ],
+)
+def test_valid_choices_conversion(valid_options, choices, expected_array):
+    valid_options["state_space"]["choices"] = choices
+    options = check_options_and_set_defaults(valid_options)
+    np.testing.assert_array_equal(options["state_space"]["choices"], expected_array)
+
+
+def test_invalid_choices_type(valid_options):
+    valid_options["state_space"]["choices"] = "not_a_valid_type"
+    with pytest.raises(ValueError, match="Choices must be a list or an integer."):
+        check_options_and_set_defaults(valid_options)
+
+
+def test_missing_model_params(valid_options):
+    del valid_options["model_params"]
+    with pytest.raises(
+        ValueError, match="Options must contain a model parameters dictionary."
+    ):
+        check_options_and_set_defaults(valid_options)
+
+
+def test_invalid_model_params_type(valid_options):
+    valid_options["model_params"] = "not_a_dict"
+    with pytest.raises(ValueError, match="Model parameters must be a dictionary."):
+        check_options_and_set_defaults(valid_options)
+
+
+# maybe also check this in the check_options_and_set_defaults function
+def test_missing_continuous_states(valid_options):
+    del valid_options["state_space"]["continuous_states"]
+    with pytest.raises(KeyError):
+        check_options_and_set_defaults(valid_options)
+
+
+def test_tuning_params_defaults(valid_options):
+    del valid_options["tuning_params"]
+    options = check_options_and_set_defaults(valid_options)
+    assert options["tuning_params"]["extra_wealth_grid_factor"] == 0.2
+    assert options["tuning_params"]["n_constrained_points_to_add"] == 1
+
+
+def test_tuning_params_invalid_grid_factors(valid_options):
+    valid_options["tuning_params"]["extra_wealth_grid_factor"] = 0.01
+    valid_options["tuning_params"]["n_constrained_points_to_add"] = 100
+    with pytest.raises(
+        ValueError, match="The extra wealth grid factor .* is too small"
+    ):
+        check_options_and_set_defaults(valid_options)
+
+
+def test_second_continuous_state_handling(valid_options):
+    options = check_options_and_set_defaults(valid_options)
+    assert options["second_continuous_state_name"] == "experience"
+    assert options["tuning_params"]["n_second_continuous_grid"] == len(
+        valid_options["state_space"]["continuous_states"]["experience"]
     )

--- a/tests/test_pre_processing.py
+++ b/tests/test_pre_processing.py
@@ -54,16 +54,16 @@ def test_wrap_function(load_replication_params_and_specs):
         {
             "state_space": {
                 "n_periods": 25,
-                "choices": np.arange(2),
+                "choices": 2,
                 "endogenous_states": {
-                    "thus": np.arange(25),
-                    "that": [0, 1],
+                    "thus": 25,
+                    "that": 2,
                 },
                 "continuous_states": {
                     "wealth": np.linspace(0, 500, 100),
                 },
                 "exogenous_processes": {
-                    "ltc": {"states": np.array([0]), "transition": jnp.array([0])}
+                    "ltc": {"states": 1, "transition": jnp.array([0])}
                 },
             },
         }
@@ -138,7 +138,7 @@ def test_load_and_save_model(
     options["model_params"]["n_choices"] = _raw_options["n_discrete_choices"]
     options["state_space"] = {
         "n_periods": 25,
-        "choices": [i for i in range(_raw_options["n_discrete_choices"])],
+        "choices": len(_raw_options["n_discrete_choices"]),
         "continuous_states": {
             "wealth": np.linspace(0, 500, 100),
         },
@@ -201,7 +201,7 @@ def test_grid_parameters():
         },
         "state_space": {
             "n_periods": 25,
-            "choices": [0, 1],
+            "choices": 2,
             "continuous_states": {
                 "wealth": np.linspace(0, 10, 100),
             },
@@ -236,11 +236,11 @@ def test_second_continuous_state(period, lagged_choice, continuous_state):
     options = {
         "state_space": {
             "n_periods": 25,
-            "choices": np.arange(3),
+            "choices": 3,
             # discrete states
             "endogenous_states": {
-                "married": [0, 1],
-                "n_children": np.arange(3),
+                "married": 2,
+                "n_children": 3,
             },
             "continuous_states": {
                 "wealth": np.linspace(0, 10_000, 100),

--- a/tests/test_replication.py
+++ b/tests/test_replication.py
@@ -39,7 +39,7 @@ def test_benchmark_models(model_name, load_replication_params_and_specs):
     options["model_params"]["n_choices"] = model_specs["n_discrete_choices"]
     options["state_space"] = {
         "n_periods": 25,
-        "choices": [i for i in range(model_specs["n_discrete_choices"])],
+        "choices": len(model_specs["n_discrete_choices"]),
         "continuous_states": {
             "wealth": jnp.linspace(
                 0,

--- a/tests/test_simulate_continuous_state.py
+++ b/tests/test_simulate_continuous_state.py
@@ -53,11 +53,9 @@ def test_setup():
 
     state_space_options = {
         "n_periods": N_PERIODS,
-        "choices": np.arange(
-            N_DISCRETE_CHOICES,
-        ),
+        "choices": N_DISCRETE_CHOICES,
         "endogenous_states": {
-            "experience": np.arange(N_PERIODS + MAX_INIT_EXPERIENCE),
+            "experience": N_PERIODS + MAX_INIT_EXPERIENCE,
         },
         "continuous_states": {
             "wealth": jnp.linspace(

--- a/tests/test_sparse_exog_and_batch_sep.py
+++ b/tests/test_sparse_exog_and_batch_sep.py
@@ -82,17 +82,17 @@ def test_benchmark_models(load_replication_params_and_specs):
     options["model_params"]["n_choices"] = model_specs["n_discrete_choices"]
     options["state_space"] = {
         "n_periods": 25,
-        "choices": np.arange(2, dtype=int),
+        "choices": 2,
         "endogenous_states": {
-            "education": np.arange(2, dtype=int),
+            "education": 2,
         },
         "exogenous_processes": {
             "health": {
-                "states": np.arange(2, dtype=int),
+                "states": 2,
                 "transition": health_transition,
             },
             "partner": {
-                "states": np.arange(2, dtype=int),
+                "states": 2,
                 "transition": partner_transition,
             },
         },

--- a/tests/test_state_space.py
+++ b/tests/test_state_space.py
@@ -24,16 +24,16 @@ def options(load_replication_params_and_specs):
         {
             "state_space": {
                 "n_periods": 25,
-                "choices": np.arange(2),
+                "choices": 2,
                 "endogenous_states": {
-                    "thus": np.arange(25),
-                    "that": [0, 1],
+                    "thus": 25,
+                    "that": 2,
                 },
                 "continuous_states": {
                     "wealth": np.linspace(0, 50, 100),
                 },
                 "exogenous_processes": {
-                    "ltc": {"states": np.array([0]), "transition": jnp.array([0])}
+                    "ltc": {"states": 1, "transition": jnp.array([0])}
                 },
             },
         }
@@ -208,11 +208,11 @@ def test_state_space():
     options_sparse = {
         "state_space": {
             "n_periods": n_periods,  # 25 + 50 = 75
-            "choices": np.arange(3, dtype=np.int64),
+            "choices": 3,
             "endogenous_states": {
-                "experience": np.arange(n_periods, dtype=int),
-                "policy_state": np.arange(36, dtype=int),
-                "retirement_age_id": np.arange(10, dtype=int),
+                "experience": n_periods,
+                "policy_state": 36,
+                "retirement_age_id": 10,
             },
             "continuous_states": {"wealth": np.linspace(0, 50, 100)},
         },

--- a/tests/test_two_period_continuous_experience.py
+++ b/tests/test_two_period_continuous_experience.py
@@ -244,7 +244,7 @@ def create_test_inputs():
 
     options["state_space"] = {
         "n_periods": N_PERIODS,
-        "choices": np.arange(2),
+        "choices": 2,
         "continuous_states": {
             "wealth": jnp.linspace(
                 0,

--- a/tests/test_utility_second_continuous.py
+++ b/tests/test_utility_second_continuous.py
@@ -221,11 +221,9 @@ def test_setup():
 
     state_space_options = {
         "n_periods": N_PERIODS,
-        "choices": np.arange(
-            N_DISCRETE_CHOICES,
-        ),
+        "choices": N_DISCRETE_CHOICES,
         "endogenous_states": {
-            "experience": np.arange(N_PERIODS + MAX_INIT_EXPERIENCE),
+            "experience": N_PERIODS + MAX_INIT_EXPERIENCE,
         },
         "continuous_states": {
             "wealth": jnp.linspace(


### PR DESCRIPTION
## Suggested Additional Checks for check_options_and_set_defaults

- [x] Check for continuous_states dict in options dict
- [x] Check for missing continuous_states keys always present like wealth:
- [x] Ensure wealth exists in continuous_states.
- [x] Check its type (e.g., list, np.ndarray) and convert 

--- 

- [x] Ensure all continuous_states values are convertible to np.ndarray and then convert them to np.ndarrays

--- 

- [x] Validate n_choices matches choices length 
       - If n_choices exists in model_params, ensure it equals the length of choices

---

- [ ] Enforce positive extra_wealth_grid_factor ?

---

- [ ] Add a check for tuning_params keys: If provided, validate their types


## Implemented Checks for check_options_and_set_defaults (that are also tested)

### Validation Checks
- [x]  Ensure options is a dictionary.
- [x]  Ensure options contains a state_space dictionary.
- [x]  Ensure state_space is a dictionary.
- [x]  Ensure state_space contains n_periods.
- [x]  Ensure n_periods is an integer.
- [x]  Ensure n_periods is greater than 1.
- [x]  Ensure choices in state_space is either a list, integer, or numpy array (if provided).
- [x]  Convert choices to a numpy array of type uint8 if present.


### Default Setting
- [x]  Set default choices to a numpy array [0] of type uint8 if not provided.
- [x]  Set default tuning_params to an empty dictionary if not provided.
- [x]  Set default tuning_params["extra_wealth_grid_factor"] to 0.2 if not provided.
- [x]  Set default tuning_params["n_constrained_points_to_add"] based on the length of the wealth grid if not provided.
- [x]  Set model_params["n_choices"] based on the length of state_space["choices"] if not explicitly provided.


### Logical Consistency
- [x]  Ensure model_params is a dictionary.
- [x]  Ensure options contains model_params.
- [x]  Validate tuning_params to ensure the extra wealth grid factor is large enough to cover the constrained wealth grid points


### Grid Preparation
- [x]  Compute the number of wealth grid points (n_wealth_grid) from the continuous_states["wealth"] grid.
- [x]  Compute the total wealth grid size (n_total_wealth_grid) based on extra_wealth_grid_factor and n_constrained_points_to_add.
- [x]  Extract exogenous grids from continuous_states.


### Secondary Continuous State
- [x]  Identify and handle the second continuous state (if continuous_states has more than one key).
- [x]  Compute the number of grid points for the second continuous state (n_second_continuous_grid).


mod Gregors Fehler